### PR TITLE
Prevent huge offline queue

### DIFF
--- a/app/reducers.js
+++ b/app/reducers.js
@@ -116,6 +116,28 @@ const currentAlerts = (state = [], action) => {
 	}
 };
 
+// Check for offline
+const offline = (state = {}, action) => {
+	case REHYDRATE: {
+		// Remove duplicate API calls to prevent overloaded queues
+		action.payload.offline.outbox = action.payload.offline.outbox.reduce((acc, call) => {
+			const { arr, map } = acc;
+			if (map.hasOwnProperty(call)) return acc;
+			arr.push(call);
+			map[call] = 0;
+
+			return { arr, map }
+		}, {
+			arr: [],
+			map: {}
+		}).arr;
+
+		return { ...state, ...action.payload.offline, busy: false };
+	}
+	case default:
+		return state;
+}
+
 // Turns different reducing functions into a single reducing function
 const reducers = combineReducers({
 	currentQuestions,

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -119,18 +119,8 @@ const currentAlerts = (state = [], action) => {
 // Check for offline
 const offline = (state = {}, action) => {
 	case REHYDRATE: {
-		// Remove duplicate API calls to prevent overloaded queues
-		action.payload.offline.outbox = action.payload.offline.outbox.reduce((acc, call) => {
-			const { arr, map } = acc;
-			if (map.hasOwnProperty(call)) return acc;
-			arr.push(call);
-			map[call] = 0;
-
-			return { arr, map }
-		}, {
-			arr: [],
-			map: {}
-		}).arr;
+		// Empty API call queue on rehydration
+		action.payload.offline.outbox = []
 
 		return { ...state, ...action.payload.offline, busy: false };
 	}


### PR DESCRIPTION
Faced an issue where there was a huge backlog of API calls because it was getting jammed by an API call at the front.  On Rehydrate (app restart), we'll empty the backlog of API calls.