### PR TITLE
Created new and closed labels for activities

### DIFF
--- a/app/components/activity/ActivityTile.js
+++ b/app/components/activity/ActivityTile.js
@@ -97,7 +97,7 @@ class ActivityTile extends Component {
 				<View
 					style={ [ActivityStyles.activityBadge, ActivityStyles.activityBadgeClosed] }
 				>
-					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextClosed] }>CLOSED!</Text>
+					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextClosed] }>CLOSED</Text>
 				</View>
 			);
 		} else if (item.isNewActivity){
@@ -105,7 +105,7 @@ class ActivityTile extends Component {
 				<View
 					style={ [ActivityStyles.activityBadge, ActivityStyles.activityBadgeNew] }
 				>
-					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextNew] }>NEW!</Text>
+					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextNew] }>NEW</Text>
 				</View>
 			);
 		} else{
@@ -146,7 +146,7 @@ class ActivityTile extends Component {
 					subtitle={ "Station " + item.station }
 					onPress={ () => this.renderActivityDetails(item) }
 					rightIcon={ icon }
-					badge={{element: badge}}
+					badge={{ element: badge }}
 				/>
 			);
 	}

--- a/app/components/activity/ActivityTile.js
+++ b/app/components/activity/ActivityTile.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import {
+	View,
+	Text,
+} from 'react-native';
 import { ListItem } from 'react-native-elements';
 import Icon from 'react-native-vector-icons/Ionicons';
 import { addActivity, removeActivity } from '../../actions';
@@ -87,8 +91,31 @@ class ActivityTile extends Component {
 		});
 	}
 
+	renderActivityBadge(item){
+		if (!item.isOpen){
+			return (
+				<View
+					style={ [ActivityStyles.activityBadge, ActivityStyles.activityBadgeClosed] }
+				>
+					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextClosed] }>CLOSED!</Text>
+				</View>
+			);
+		} else if (item.isNewActivity){
+			return (
+				<View
+					style={ [ActivityStyles.activityBadge, ActivityStyles.activityBadgeNew] }
+				>
+					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextNew] }>NEW!</Text>
+				</View>
+			);
+		} else{
+			return (<View />);
+		}
+	}
+
 	render() {
 		const { item, isAdded } = this.state;
+		const badge = this.renderActivityBadge(item);
 		const icon = isAdded
 			? (
 				<Icon
@@ -119,6 +146,7 @@ class ActivityTile extends Component {
 					subtitle={ "Station " + item.station }
 					onPress={ () => this.renderActivityDetails(item) }
 					rightIcon={ icon }
+					badge={{element: badge}}
 				/>
 			);
 	}

--- a/app/styles/ActivityStyles.js
+++ b/app/styles/ActivityStyles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native'
 import {
-	darkBlue, 
+	darkBlue,
 	lightGray,
 	darkGray,
 	green,
@@ -169,6 +169,34 @@ const ActivityStyles = StyleSheet.create({
 		backgroundColor:grayBlue,
 		borderRadius: 10,
 		fontSize: 16,
+	},
+	activityBadge: {
+		width: 70,
+		height: 20,
+		marginTop: 10,
+		marginRight:75,
+		paddingVertical: 2,
+		borderRadius : 20,
+		borderWidth: 1,
+		backgroundColor: "white",
+		overflow: 'hidden',
+	},
+	badgeText: {
+		fontSize: 10,
+		fontWeight: "300",
+		textAlign: "center",
+	},
+	activityBadgeNew: {
+		borderColor: green,
+	},
+	badgeTextNew: {
+		color: green,
+	},
+	activityBadgeClosed: {
+		borderColor: deleteRed,
+	},
+	badgeTextClosed: {
+		color: deleteRed,
 	},
 });
 


### PR DESCRIPTION
Issue: #131 
Added "new" and "closed" labels to activities according to designs
If an activity is labelled as both, the "closed" label takes priority
Screenshot: 
https://user-images.githubusercontent.com/15674572/37499741-d01f4234-289b-11e8-8331-45c499f0f978.jpg
