### PR TITLE
Move banner heading for closed activities + Adjust activity badge

### DIFF
--- a/app/components/activity/ActivityDetails.js
+++ b/app/components/activity/ActivityDetails.js
@@ -25,12 +25,12 @@ class ActivityDetails extends React.Component {
 			const errorMessage = "CLOSED: " + (activity.state ? activity.state : "This event is currently closed due to unforeseen circumstances, thanks for your understanding!");
 			const selectedHeader = activity.isOpen ? defaultHeader : (
 				<View>
+					{ defaultHeader }
 					<View style={ ActivityStyles.errorMessage }>
 						<Text style={ ActivityStyles.errorMessageText }>
 							{ errorMessage }
 						</Text>
 					</View>
-					{ defaultHeader }
 				</View>
 			);
 			return selectedHeader;

--- a/app/components/activity/MyScheduleTile.js
+++ b/app/components/activity/MyScheduleTile.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { View, Text } from 'react-native';
 import { connect } from 'react-redux';
 import { ListItem, Icon } from 'react-native-elements';
 import { addActivity, removeActivity } from '../../actions';
@@ -74,8 +75,31 @@ class ActivityTile extends Component {
 		});
 	}
 
+	renderActivityBadge(item){
+		if (!item.isOpen){
+			return (
+				<View
+					style={ [ActivityStyles.activityBadge, ActivityStyles.activityBadgeClosed] }
+				>
+					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextClosed] }>CLOSED</Text>
+				</View>
+			);
+		} else if (item.isNewActivity){
+			return (
+				<View
+					style={ [ActivityStyles.activityBadge, ActivityStyles.activityBadgeNew] }
+				>
+					<Text style={ [ActivityStyles.badgeText, ActivityStyles.badgeTextNew] }>NEW</Text>
+				</View>
+			);
+		} else{
+			return (<View />);
+		}
+	}
+
 	render() {
 		const { item } = this.state;
+		const badge = this.renderActivityBadge(item);
 
 		if (this.props.isEditing) {
 			const icon = (
@@ -95,7 +119,7 @@ class ActivityTile extends Component {
 					key={ item.id }
 					title={ item.title }
 					subtitle={ "Station " + item.station }
-					// onPressRightIcon={  }
+					badge={{ element: badge }}
 					rightIcon={ icon }
 				/>
 			);
@@ -119,6 +143,7 @@ class ActivityTile extends Component {
 					subtitle={ "Station " + item.station }
 					onPress={ () => this.renderActivityDetails(item) }
 					rightIcon={ icon }
+					badge={{ element: badge }}
 				/>
 			);
 		}

--- a/app/styles/ActivityStyles.js
+++ b/app/styles/ActivityStyles.js
@@ -174,7 +174,7 @@ const ActivityStyles = StyleSheet.create({
 	activityBadge: {
 		width: 70,
 		height: 20,
-		marginTop: 10,
+		marginTop: 20,
 		marginRight:75,
 		paddingVertical: 2,
 		borderRadius : 20,


### PR DESCRIPTION
Moves the banner heading for closed activities so it is easier to view on large viewports. Adjusts activity badge margin and adds activity badge to my schedule

<img width="406" alt="screen shot 2018-03-28 at 4 52 32 pm" src="https://user-images.githubusercontent.com/18689448/38055781-ae689bc4-32a8-11e8-96a2-df1591aca7dd.png">

<img width="385" alt="screen shot 2018-03-28 at 4 52 27 pm" src="https://user-images.githubusercontent.com/18689448/38055780-acfaaa0c-32a8-11e8-8d5e-78fc2c15f655.png">
